### PR TITLE
fix: implement custom 404 pages for locale and global handling (#19)

### DIFF
--- a/src/app/[locale]/[...rest]/page.tsx
+++ b/src/app/[locale]/[...rest]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation';
+
+export default function CatchAllPage() {
+  notFound();
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -51,6 +51,6 @@ export default async function LocaleLayout({
           </NextIntlClientProvider>
         </ThemeProvider>
       </body>
-    </html >
+    </html>
   );
 };

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+import { useLocale } from 'next-intl';
+
+/**
+ * @see https://github.com/amannn/next-intl/tree/main/examples/example-app-router
+ */
+export default function LocaleNotFoundPage() {
+  const locale = useLocale();
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-10 mt-24">
+      <div className="flex flex-col items-center gap-2">
+        <h1 className="flex items-center gap-2 text-9xl font-bold text-primary">
+          404
+        </h1>
+        <h1 className="flex max-w-sm items-center gap-5 text-center text-sm text-gray-300">
+          The page you are looking for doesn&apos;t exist. Please go back to the
+          home page.
+        </h1>
+      </div>
+      <Link href={`/${locale}`}>
+        <Button>
+          Home
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,23 +1,13 @@
-import { Button } from '@/components/ui/button';
-import Link from 'next/link';
-
-export default function NotFound() {
+'use client';
+ 
+import Error from 'next/error';
+ 
+export default function GlobalNotFound() {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-10 mt-24">
-      <div className="flex flex-col items-center gap-2">
-        <h1 className="flex items-center gap-2 text-9xl font-bold text-primary">
-          404
-        </h1>
-        <h1 className="flex max-w-sm items-center gap-5 text-center text-sm text-gray-300">
-          The page you are looking for doesn&apos;t exist. Please go back to the
-          home page.
-        </h1>
-      </div>
-      <Link href="/">
-        <Button>
-          Home
-        </Button>
-      </Link>
-    </div>
+    <html lang="en">
+      <body>
+        <Error statusCode={404} />
+      </body>
+    </html>
   );
 }


### PR DESCRIPTION
This pull request introduces changes to handle 404 error pages more effectively in a Next.js application. It includes the creation of a locale-specific 404 page, a catch-all page for unmatched routes, and updates to the global 404 page.

Error handling improvements:

* `src/app/[locale]/[...rest]/page.tsx`: Added a catch-all page that triggers a 404 error for any unmatched routes. ([src/app/[locale]/[...rest]/page.tsxR1-R5](diffhunk://#diff-d18a9160af7d5c8ba904b787fe994f120ebdc5272d9dc28073ebfab680df63edR1-R5))
* `src/app/[locale]/not-found.tsx`: Created a locale-specific 404 error page with a user-friendly message and a button to navigate back to the home page. ([src/app/[locale]/not-found.tsxR1-R28](diffhunk://#diff-f2f9f92035a4c77a8790ed6a7ee8be22b96f7055c97af27c220503e2596afa36R1-R28))
* [`src/app/not-found.tsx`](diffhunk://#diff-f656f59519a290bb5f099f48ce59a37b32c20b0276f0e83e884051f0be43db43L1-R11): Updated the global 404 error page to use the `next/error` component for a simpler and more consistent error display.