### PR TITLE
feat: add @next/third-parties dependency and integrate Google Tag Manager in layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
+    "@next/third-parties": "^15.1.6",
     "@primer/octicons-react": "^19.15.0",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.54.2(react@19.0.0))
+      '@next/third-parties':
+        specifier: ^15.1.6
+        version: 15.1.6(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       '@primer/octicons-react':
         specifier: ^19.15.0
         version: 19.15.0(react@19.0.0)
@@ -640,6 +643,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@15.1.6':
+    resolution: {integrity: sha512-F0uemUqFwD3lLx5SrWXYRe9dZvMVkO0rFuMnvLiPBcagxNc23Ufl5cNXEm4Yuo8O1Mu8dgh+VjExMz1Td4vBew==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2685,6 +2694,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -3432,6 +3444,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.1.6':
     optional: true
+
+  '@next/third-parties@15.1.6(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      next: 15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5779,6 +5797,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  third-party-capital@1.0.20: {}
 
   tiny-invariant@1.3.3: {}
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,8 @@ import { setRequestLocale, getMessages } from 'next-intl/server';
 import ThemeProvider from "@/components/theme/theme-provider";
 import { routing } from '@/i18n/routing';
 import { inter } from "@/app/font";
+import { GoogleTagManager } from '@next/third-parties/google'
+
 
 import "@/app/globals.css";
 
@@ -61,6 +63,9 @@ export default async function LocaleLayout({
   const messages = await getMessages();
   return (
     <html lang={locale} className={`${inter.variable}`} suppressHydrationWarning>
+      <GoogleTagManager
+        gtmId={process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID ?? ""}
+      />
       <body>
         <ThemeProvider
           attribute="class"


### PR DESCRIPTION
This pull request includes several updates to dependencies and the integration of a new third-party package. The key changes involve adding the `@next/third-parties` package and updating the `locale` layout to include Google Tag Manager.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R13): Added `@next/third-parties` dependency with version `^15.1.6`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14-R16): Added `@next/third-parties` with version `15.1.6` and its peer dependencies. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14-R16) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR647-R652)

Integration of new third-party package:

* `src/app/[locale]/layout.tsx`: Imported `GoogleTagManager` from `@next/third-parties/google` and added it to the layout component. ([src/app/[locale]/layout.tsxR8-R9](diffhunk://#diff-d387de9ed27220b8f151f3debc731746f2804b3e509aa2f99de6d40137df203aR8-R9), [src/app/[locale]/layout.tsxR66-R68](diffhunk://#diff-d387de9ed27220b8f151f3debc731746f2804b3e509aa2f99de6d40137df203aR66-R68))