### PR TITLE
feat: enhance homepage with GitHub stars display and new buttons for navigation

### DIFF
--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -2,8 +2,19 @@ import React from "react"
 import Hero from "@/components/section/hero";
 import { Gradient } from "@/components/gradient";
 import { Particles } from "@/components/magicui/particles";
+import { ArrowRightIcon } from "@radix-ui/react-icons";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { AnimatedShinyText } from "@/components/magicui/animated-shiny-text";
+import { Button } from "@/components/ui/button"
+import { Suspense } from "react"
+import { GitHubStars, GitHubStarsFallback } from "@/components/section/github-stars"
+import { ArrowUpRightIcon } from "@primer/octicons-react"
+import { useLocale } from "next-intl"
+
 
 export default function HomePage() {
+  const locale = useLocale()
   return (
     <>
       <Gradient />
@@ -12,8 +23,52 @@ export default function HomePage() {
         quantity={50}
       />
       <main className='relative mx-auto mb-16 max-w-4xl px-8 py-24'>
-        <div className="mt-6 flex flex-col items-center justify-center">
+        <div className="mt-10 z-10 flex items-center justify-center">
+          <div
+            className={cn(
+              "group rounded-full border border-black/5 bg-neutral-100 text-base text-white transition-all ease-in hover:cursor-pointer hover:bg-neutral-200 dark:border-white/5 dark:bg-neutral-900 dark:hover:bg-neutral-800",
+            )}
+          >
+            <Link
+              href="https://github.com/1chooo/stonix/stargazers"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Star on GitHub"
+            >
+              <AnimatedShinyText className="inline-flex items-center justify-center px-4 py-1 transition ease-out hover:text-neutral-600 hover:duration-300 hover:dark:text-neutral-400">
+                <span>✨ Proudly Open Source</span>
+                <ArrowRightIcon className="ml-1 size-3 transition-transform duration-300 ease-in-out group-hover:translate-x-0.5" />
+              </AnimatedShinyText>
+            </Link>
+          </div>
+        </div>
+        <div className="mt-10 flex flex-col items-center justify-center">
           <Hero />
+          <div className="my-10 grid gap-2 sm:grid-cols-2">
+            <div className="text-center sm:block sm:text-right">
+              <Button className="w-48 rounded-full sm:w-auto" asChild>
+                <Link href={`/${locale}/dashboard`}>
+                  Get Started
+                  <ArrowUpRightIcon className="ml-2 h-5 w-5" />
+                </Link>
+              </Button>
+            </div>
+            <div className="text-center sm:block sm:text-left">
+              <Button variant="outline" className="w-48 rounded-full sm:w-auto" asChild>
+                <Link
+                  href="https://github.com/1chooo/stonix"
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label="Star on GitHub"
+                >
+                  Star on GitHub{" "}
+                  <Suspense fallback={<GitHubStarsFallback />}>
+                    <GitHubStars />
+                  </Suspense>
+                </Link>
+              </Button>
+            </div>
+          </div>
         </div>
       </main>
     </>

--- a/src/components/section/github-stars.tsx
+++ b/src/components/section/github-stars.tsx
@@ -1,0 +1,25 @@
+import { Badge } from "@/components/ui/badge";
+import { getGitHubStars } from "@/lib/github";
+import { numberFormatter } from "@/lib/utils";
+
+export async function GitHubStars() {
+  const stars = await getGitHubStars();
+  return (
+    <>
+      <Badge variant="secondary" className="ml-1 hidden sm:block">
+        {numberFormatter(stars)}
+      </Badge>
+      <Badge variant="secondary" className="ml-1 block sm:hidden">
+        {stars}
+      </Badge>
+    </>
+  );
+}
+
+export function GitHubStarsFallback() {
+  return (
+    <Badge variant="secondary" className="ml-1">
+      ~
+    </Badge>
+  );
+}

--- a/src/components/section/hero.tsx
+++ b/src/components/section/hero.tsx
@@ -1,12 +1,8 @@
-"use client";
+"use client"
 
-import Link from "next/link"
-import { cva } from "class-variance-authority"
 import { motion } from "motion/react"
-import { useEffect, useState } from "react";
-import { ArrowUpRightIcon } from "@primer/octicons-react";
-import { useTranslations } from 'next-intl';
-import { useLocale } from "next-intl";
+import { useEffect, useState } from "react"
+import { useTranslations } from "next-intl"
 
 const containerVariants = {
   initial: {
@@ -25,7 +21,7 @@ const containerVariants = {
       },
     },
   },
-};
+}
 
 const h1Variants = {
   initial: { opacity: 0, y: 20 },
@@ -38,7 +34,7 @@ const h1Variants = {
       damping: 20,
     },
   },
-};
+}
 
 const h2Variants = {
   initial: { opacity: 0, y: -20 },
@@ -52,7 +48,7 @@ const h2Variants = {
       delay: 0.7,
     },
   },
-};
+}
 
 const nameVariants = {
   initial: {
@@ -69,62 +65,31 @@ const nameVariants = {
       delay: 0.4,
     },
   },
-};
-
-const buttonVariants = cva(
-  [
-    "ring-offset-background inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors",
-    "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-    "disabled:pointer-events-none disabled:opacity-50"
-  ],
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border-input bg-background hover:bg-accent hover:text-accent-foreground border",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline"
-      },
-      size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 px-3",
-        lg: "h-11 px-8",
-        icon: "size-10"
-      }
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default"
-    }
-  }
-)
+}
 
 export default function Hero() {
-  const t = useTranslations("HomePage");
-  const locale = useLocale();
+  const t = useTranslations("HomePage")
 
   function BlinkingCursor() {
-    const [isVisible, setIsVisible] = useState(true);
+    const [isVisible, setIsVisible] = useState(true)
 
     useEffect(() => {
       const interval = setInterval(() => {
-        setIsVisible((v) => !v);
-      }, 533);
+        setIsVisible((v) => !v)
+      }, 533)
 
-      return () => clearInterval(interval);
-    }, []);
+      return () => clearInterval(interval)
+    }, [])
 
     return isVisible ? (
       <div className={"inline-block text-purple-700"}>_</div>
     ) : (
       <div className={"inline-block invisible"}>_</div>
-    );
+    )
   }
 
   return (
-    <div className="my-24 space-y-8">
+    <div className="space-y-8">
       <motion.div
         variants={containerVariants}
         initial="initial"
@@ -137,14 +102,14 @@ export default function Hero() {
           animate="animate"
           className="text-center text-4xl font-bold sm:text-8xl"
         >
-          {t('title')}{" "}
+          {t("title")}{" "}
           <motion.span
             variants={nameVariants}
             initial="initial"
             animate="animate"
             className="block text-6xl sm:text-8xl sm:inline-block bg-gradient-to-r from-blue-500 to-purple-700 bg-clip-text text-transparent"
           >
-            {t('project')}
+            {t("project")}
             <BlinkingCursor />
           </motion.span>
         </motion.h1>
@@ -154,18 +119,12 @@ export default function Hero() {
           animate="animate"
           className="px-4 py-6 text-center text-lg md:text-xl text-gh-text-secondary"
         >
-          {t('subtitle')}
+          {t("subtitle")}
         </motion.h2>
       </motion.div>
       <p className="leading-6 text-muted-foreground text-center max-w-2xl mx-auto text-lg md:text-xl">
-        {t('description')}
+        {t("description")}
       </p>
-      <div className="flex gap-4 justify-center align-middle">
-        <Link href={`/${locale}/dashboard`} className={buttonVariants()}>
-          {t('start')}
-          <ArrowUpRightIcon className="ml-2 h-5 w-5" />
-        </Link>
-      </div>
     </div>
   )
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,17 @@
+import * as z from "zod";
+
+const schema = z.object({
+  stargazers_count: z.number(),
+});
+
+export async function getGitHubStars() {
+  const res = await fetch(
+    "https://api.github.com/repos/1chooo/stonix",
+    { next: { revalidate: 600 } }, // 10min
+  );
+  const json = await res.json();
+  const github = schema.safeParse(json);
+
+  if (!github.success) return 0;
+  return github.data.stargazers_count;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge";
 export const cn = (...inputs: ClassValue[]) => {
   return twMerge(clsx(inputs));
 };
+
+
+export function numberFormatter(value: number) {
+  const formatter = Intl.NumberFormat("en", { notation: "compact" });
+  return formatter.format(value);
+}
+


### PR DESCRIPTION
This pull request introduces several new features and improvements to the `HomePage` component and related files. The most significant changes include adding new UI elements, refactoring existing components, and creating utility functions to support these new features.

### New UI Elements:

* `src/app/[locale]/(home)/page.tsx`: Added new components such as `ArrowRightIcon`, `Link`, `AnimatedShinyText`, `Button`, `GitHubStars`, and `ArrowUpRightIcon` to enhance the homepage with additional interactive elements and links. ([src/app/[locale]/(home)/page.tsxR5-R17](diffhunk://#diff-3d7ef3a12027292c73eda642d70656132bbec56f74d29d6dd88b01209cc2e67fR5-R17), [src/app/[locale]/(home)/page.tsxL15-R71](diffhunk://#diff-3d7ef3a12027292c73eda642d70656132bbec56f74d29d6dd88b01209cc2e67fL15-R71))

### Component Refactoring:

* [`src/components/section/hero.tsx`](diffhunk://#diff-4ebcef995b88e366d6d2779b0df67f5431e82bd2461250b705a1c9b1efb5e6d7L1-R5): Refactored the `Hero` component by removing unused imports and simplifying the code structure. This includes removing the `buttonVariants` definition and related code. [[1]](diffhunk://#diff-4ebcef995b88e366d6d2779b0df67f5431e82bd2461250b705a1c9b1efb5e6d7L1-R5) [[2]](diffhunk://#diff-4ebcef995b88e366d6d2779b0df67f5431e82bd2461250b705a1c9b1efb5e6d7L28-R24) [[3]](diffhunk://#diff-4ebcef995b88e366d6d2779b0df67f5431e82bd2461250b705a1c9b1efb5e6d7L41-R37) [[4]](diffhunk://#diff-4ebcef995b88e366d6d2779b0df67f5431e82bd2461250b705a1c9b1efb5e6d7L55-R51) [[5]](diffhunk://#diff-4ebcef995b88e366d6d2779b0df67f5431e82bd2461250b705a1c9b1efb5e6d7L72-R92) [[6]](diffhunk://#diff-4ebcef995b88e366d6d2779b0df67f5431e82bd2461250b705a1c9b1efb5e6d7L140-R112) [[7]](diffhunk://#diff-4ebcef995b88e366d6d2779b0df67f5431e82bd2461250b705a1c9b1efb5e6d7L157-L168)

### New Utility Functions:

* [`src/lib/github.ts`](diffhunk://#diff-1694b20d1194df7e39a31c079e2ecf60319839b84d39cba2a5b2e765321960b8R1-R17): Created a new function `getGitHubStars` to fetch the number of stars from the GitHub repository, with validation using `zod`.
* [`src/lib/utils.ts`](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224R7-R13): Added a `numberFormatter` function to format numbers in a compact notation.

### New Components:

* [`src/components/section/github-stars.tsx`](diffhunk://#diff-39f4891a956d585d3846822be0cce8ef5900ff118d9a554cacda294f60ea7d62R1-R25): Introduced `GitHubStars` and `GitHubStarsFallback` components to display the number of stars from the GitHub repository with a fallback for loading states.